### PR TITLE
Change ROCM_DIR to fetch the correct library path

### DIFF
--- a/goamdsmi_shim/amd_smi.cmake
+++ b/goamdsmi_shim/amd_smi.cmake
@@ -11,4 +11,4 @@ set(WITH_ROCM_SMI ON CACHE BOOL "")
 
 # path to global esmi and rocm_smi install
 set(ESMI_DIR "/opt/e-sms/e_smi" CACHE PATH "")
-set(ROCM_SMI_DIR "/opt/rocm/rocm_smi/" CACHE PATH "")
+set(ROCM_SMI_DIR "/opt/rocm" CACHE PATH "")


### PR DESCRIPTION
Latest "https://github.com/RadeonOpenCompute/rocm_smi_lib" installation path has been changed under "/opt/rocm". So, change as per path.

Observed Compilation errors becuase of rocm installation path:
/home/devika/Goamdsmi/go_amd_smi/goamdsmi_shim/rsmi/rocm_smi_go_shim.c:41:10: fatal error: rocm_smi/rocm_smi.h: No such file or directory                    │
   41 | #include <rocm_smi/rocm_smi.h>                                                                                                                       │
      |          ^~~~~~~~~~~~~~~~~~~~~                                                                                                                       │
compilation terminated.

Also, Observed compilation error below for not finding lib path:

muralimk@ppac-123-b2-6:~/GO/amd_smi_exporter/src$ make make clean
make[1]: Entering directory '/home/muralimk/GO/amd_smi_exporter/src' rm -rf amd_smi_exporter go.mod go.sum
make[1]: Leaving directory '/home/muralimk/GO/amd_smi_exporter/src' go mod init src
go: creating new go.mod: module src
go: to add module requirements and sums:
        go mod tidy
go get golang.org/x/exp/slices
go: added golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f go get github.com/prometheus/client_golang
go: added github.com/prometheus/client_golang v1.19.0 go get github.com/prometheus/client_golang/prometheus go get github.com/prometheus/client_golang/prometheus/promhttp go get github.com/amd/go_amd_smi@master
go: added github.com/amd/go_amd_smi v1.0.1-0.20230621071005-923fd54baef9 go build -o amd_smi_exporter main.go cpu_data.go
/usr/local/go1.22.2.linux-amd64/pkg/tool/linux_amd64/link: running gcc failed: exit status 1 /usr/bin/ld: cannot find -lrocm_smi64: No such file or directory collect2: error: ld returned 1 exit status

make: *** [Makefile:9: build] Error 1