### PR TITLE
add metrics to support 3rd party system monitor

### DIFF
--- a/goamdsmi.go
+++ b/goamdsmi.go
@@ -51,12 +51,32 @@ func GO_rsmi_init() (uint) {
 	return uint(C.go_shim_rsmi_init())
 }
 
+func GO_rsmi_shutdown() (uint) {
+        return uint(C.go_shim_rsmi_shutdown())
+}
+
 func GO_rsmi_num_monitor_devices() (uint) {
 	return uint(C.go_shim_rsmi_num_monitor_devices())
 }
 
+func GO_rsmi_dev_name_get(i int) (*C.char) {
+        return C.go_shim_rsmi_dev_name_get(C.uint(i))
+}
+
 func GO_rsmi_dev_id_get(i int) (C.uint16_t) {
 	return C.uint16_t(C.go_shim_rsmi_dev_id_get(C.uint(i)))
+}
+
+func GO_rsmi_dev_pci_id_get(i int) (C.uint64_t) {
+        return C.go_shim_rsmi_dev_pci_id_get(C.uint(i))
+}
+
+func GO_rsmi_dev_vbios_version_get(i int) (*C.char) {
+        return C.go_shim_rsmi_dev_vbios_version_get(C.uint(i))
+}
+
+func GO_rsmi_dev_vendor_name_get(i int) (*C.char) {
+        return C.go_shim_rsmi_dev_vendor_name_get(C.uint(i))
 }
 
 func GO_rsmi_dev_power_cap_get(i int) (C.uint64_t) {
@@ -71,12 +91,40 @@ func GO_rsmi_dev_temp_metric_get(i int, sensor int, metric int) (C.uint64_t) {
 	return C.go_shim_rsmi_dev_temp_metric_get(C.uint(i), C.uint(sensor), C.uint(metric))
 }
 
+func GO_rsmi_dev_perf_level_get(i int) (C.uint32_t) {
+        return C.go_shim_rsmi_dev_perf_level_get(C.uint(i))
+}
+
+func GO_rsmi_dev_overdrive_level_get(i int) (C.uint32_t) {
+        return C.go_shim_rsmi_dev_overdrive_level_get(C.uint(i))
+}
+
+func GO_rsmi_dev_mem_overdrive_level_get(i int) (C.uint32_t) {
+        return C.go_shim_rsmi_dev_mem_overdrive_level_get(C.uint(i))
+}
+
 func GO_rsmi_dev_gpu_clk_freq_get_sclk(i int) (C.uint64_t) {
 	return C.go_shim_rsmi_dev_gpu_clk_freq_get_sclk(C.uint(i))
 }
 
 func GO_rsmi_dev_gpu_clk_freq_get_mclk(i int) (C.uint64_t) {
 	return C.go_shim_rsmi_dev_gpu_clk_freq_get_mclk(C.uint(i))
+}
+
+func GO_rsmi_od_volt_freq_range_min_get_sclk(i int) (C.uint64_t) {
+        return C.go_shim_rsmi_od_volt_freq_range_min_get_sclk(C.uint(i))
+}
+
+func GO_rsmi_od_volt_freq_range_min_get_mclk(i int) (C.uint64_t) {
+        return C.go_shim_rsmi_od_volt_freq_range_min_get_mclk(C.uint(i))
+}
+
+func GO_rsmi_od_volt_freq_range_max_get_sclk(i int) (C.uint64_t) {
+        return C.go_shim_rsmi_od_volt_freq_range_max_get_sclk(C.uint(i))
+}
+
+func GO_rsmi_od_volt_freq_range_max_get_mclk(i int) (C.uint64_t) {
+        return C.go_shim_rsmi_od_volt_freq_range_max_get_mclk(C.uint(i))
 }
 
 func GO_rsmi_dev_gpu_busy_percent_get(i int) (C.uint64_t) {

--- a/goamdsmi_shim/rsmi/rocm_smi_go_shim.c
+++ b/goamdsmi_shim/rsmi/rocm_smi_go_shim.c
@@ -45,6 +45,11 @@ int32_t go_shim_rsmi_init()
 	return (RSMI_STATUS_SUCCESS == rsmi_init(0)) ? 1 : 0;
 }
 
+int32_t go_shim_rsmi_shutdown()
+{
+        return (RSMI_STATUS_SUCCESS == rsmi_shut_down()) ? 1 : 0;
+}
+
 int32_t go_shim_rsmi_num_monitor_devices()
 {
 	uint32_t num_monitor_devs = 0;
@@ -55,6 +60,20 @@ int32_t go_shim_rsmi_num_monitor_devices()
 	return 0;
 }
 
+char* go_shim_rsmi_dev_name_get(uint32_t dv_ind)
+{
+        uint32_t len = 256;
+        char *dev_name = (char*)malloc(sizeof(char)*len);
+        dev_name[0] = '\0';
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_name_get(dv_ind, dev_name, &len))
+        {
+                return dev_name;
+        }
+
+        return NULL;
+}
+
 uint16_t go_shim_rsmi_dev_id_get(uint32_t dv_ind)
 {
 	uint16_t id = 0;
@@ -63,6 +82,42 @@ uint16_t go_shim_rsmi_dev_id_get(uint32_t dv_ind)
 		return id;
 
 	return 0;
+}
+
+uint64_t go_shim_rsmi_dev_pci_id_get(uint32_t dv_ind)
+{
+        uint64_t id = 0;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_pci_id_get(dv_ind, &id))
+                return id;
+
+        return 0;
+}
+
+char* go_shim_rsmi_dev_vendor_name_get(uint32_t dv_ind)
+{
+        uint32_t len = 256;
+        char *vendor_name = (char*)malloc(sizeof(char)*len);
+        vendor_name[0] = '\0';
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_vendor_name_get(dv_ind, vendor_name, &len))
+                return vendor_name;
+
+        return NULL;
+}
+
+char* go_shim_rsmi_dev_vbios_version_get(uint32_t dv_ind)
+{
+        uint32_t len = 256;
+        char *vbios_ver = (char*)malloc(sizeof(char)*len);
+        vbios_ver[0] = '\0';
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_vbios_version_get(dv_ind, vbios_ver, &len))
+        {
+                return vbios_ver;
+        }
+
+        return NULL;
 }
 
 uint64_t go_shim_rsmi_dev_power_cap_get(uint32_t dv_ind)
@@ -95,6 +150,36 @@ uint64_t go_shim_rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor, uint
 	return 0;
 }
 
+uint32_t go_shim_rsmi_dev_overdrive_level_get(uint32_t dv_ind)
+{
+        uint32_t od;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_overdrive_level_get(dv_ind, &od))
+                return od;
+
+        return 0;
+}
+
+uint32_t go_shim_rsmi_dev_mem_overdrive_level_get(uint32_t dv_ind)
+{
+        uint32_t od;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_mem_overdrive_level_get(dv_ind, &od))
+                return od;
+
+        return 0;
+}
+
+uint32_t go_shim_rsmi_dev_perf_level_get(uint32_t dv_ind)
+{
+        rsmi_dev_perf_level_t perf;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_perf_level_get(dv_ind, &perf))
+                return perf;
+
+        return 0;
+}
+
 uint64_t go_shim_rsmi_dev_gpu_clk_freq_get_sclk(uint32_t dv_ind)
 {
 	rsmi_frequencies_t freq;
@@ -115,6 +200,45 @@ uint64_t go_shim_rsmi_dev_gpu_clk_freq_get_mclk(uint32_t dv_ind)
 	return 0;
 }
 
+uint64_t go_shim_rsmi_od_volt_freq_range_min_get_sclk(uint32_t dv_ind)
+{
+        rsmi_od_volt_freq_data_t odv;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_od_volt_info_get(dv_ind, &odv))
+                return odv.curr_sclk_range.lower_bound;
+
+        return 0;
+}
+
+uint64_t go_shim_rsmi_od_volt_freq_range_min_get_mclk(uint32_t dv_ind)
+{
+        rsmi_od_volt_freq_data_t odv;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_od_volt_info_get(dv_ind, &odv))
+                return odv.curr_mclk_range.lower_bound;
+
+        return 0;
+}
+
+uint64_t go_shim_rsmi_od_volt_freq_range_max_get_sclk(uint32_t dv_ind)
+{
+        rsmi_od_volt_freq_data_t odv;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_od_volt_info_get(dv_ind, &odv))
+                return odv.curr_sclk_range.upper_bound;
+
+        return 0;
+}
+
+uint64_t go_shim_rsmi_od_volt_freq_range_max_get_mclk(uint32_t dv_ind)
+{
+        rsmi_od_volt_freq_data_t odv;
+
+        if(RSMI_STATUS_SUCCESS == rsmi_dev_od_volt_info_get(dv_ind, &odv))
+                return odv.curr_mclk_range.upper_bound;
+
+        return 0;
+}
 
 uint64_t go_shim_rsmi_dev_gpu_busy_percent_get(uint32_t dv_ind)
 {

--- a/goamdsmi_shim/rsmi/rocm_smi_go_shim.h
+++ b/goamdsmi_shim/rsmi/rocm_smi_go_shim.h
@@ -46,6 +46,16 @@
 int32_t go_shim_rsmi_init();
 
 /**
+ *  @brief Go language stub to shut down the ROCm-SMI library
+ *  and do necessary clean up
+ *
+ *  @retval ::int32_t value of 1 upon success
+ *  @retval Zero is returned upon failure.
+ *
+ */
+int32_t go_shim_rsmi_shutdown();
+
+/**
  *  @brief Go language stub to get the number of GPU devices
  *
  *  @details This function will call the rsmi_num_monitor_devices()
@@ -62,6 +72,23 @@ int32_t go_shim_rsmi_init();
 int32_t go_shim_rsmi_num_monitor_devices();
 
 /**
+ *  @brief Go language stub to get the gpu device name string
+ *
+ *  @details This function will call the rsmi_dev_name_get()
+ *  function to write the gpu device name string (up to len characters)
+ *  for device dv_ind and return a char pointer. This value is then
+ *  passed as char * to the Go routine that called it. The caller of this
+ *  function must free the allocated buffer for the device name.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::char* VBIOS identifier
+ *  @retval NULL is returned upon failure.
+ *
+ */
+char* go_shim_rsmi_dev_name_get(uint32_t dv_ind);
+
+/**
  *  @brief Go language stub to get the GPU device id
  *
  *  @details This function will call the rsmi_dev_id_get()
@@ -76,6 +103,59 @@ int32_t go_shim_rsmi_num_monitor_devices();
  *
  */
 uint16_t go_shim_rsmi_dev_id_get(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the GPU unique pci id
+ *
+ *  @details This function will call the rsmi_dev_pci_id_get()
+ *  function to return the unique PCI device identifier
+ *  associated for a device. This value is then passed as
+ *  a uint64_t val to the Go routine that called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint64_t value of pci id
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint64_t go_shim_rsmi_dev_pci_id_get(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the VBIOS identifier string
+ *
+ *  @details This function will call the rsmi_dev_vbios_ver_get()
+ *  function to write the VBIOS char array (up to len characters)
+ *  for device dv_ind and return a char pointer. This value is then
+ *  passed as char pointer to the Go routine that called it. The caller
+ *  of this funcion must free the allocated buffer for the vbios
+ *  identifier
+ *
+ *  @param[in] ::uint32_t device index
+ *  @param[in] ::char* vbios buffer of length
+ *
+ *  @retval ::char* VBIOS identifier
+ *  @retval NULL is returned upon failure
+ *
+ */
+char* go_shim_rsmi_dev_vbios_version_get(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the vendor
+ *
+ *  @details This function will call the rsmi_dev_vendor_name_get()
+ *  function to write the name of the vendor char array (up to len
+ *  characters) for a device dv_ind and return a char pointer. This
+ *  value is then passed as a char pointer to the Go routine that
+ *  called it. The caller of this funcion must free the allocated
+ *  buffer for the vbios identifier
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint16_t value of subsystem id
+ *  @retval NULL is returned upon failure.
+ *
+ */
+char* go_shim_rsmi_dev_vendor_name_get(uint32_t dv_ind);
 
 /**
  *  @brief Go language stub to get the GPU power cap
@@ -126,6 +206,54 @@ uint64_t go_shim_rsmi_dev_power_ave_get(uint32_t dv_ind);
 uint64_t go_shim_rsmi_dev_temp_metric_get(uint32_t dv_ind, uint32_t sensor, uint32_t metric);
 
 /**
+ *  @brief Go language stub to get the overdrive level of the device
+ *
+ *  @details This function will call the rsmi_dev_overdrive_level_get()
+ *  function to return the overdrive percentage. This value is then
+ *  passed as a uint32_t val to the Go routine that
+ *  called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint32_t overdrive level
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint32_t go_shim_rsmi_dev_overdrive_level_get(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the memory overdrive level of the device
+ *
+ *  @details This function will call the rsmi_dev_mem_overdrive_level_get()
+ *  function to return the memory overdrive percentage. This value is then
+ *  passed as a uint32_t val to the Go routine that
+ *  called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint32_t memory overdrive level
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint32_t go_shim_rsmi_dev_mem_overdrive_level_get(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the performance level of the device
+ *
+ *  @details This function will call the rsmi_dev_perf_level_get()
+ *  function to return the  rsmi_dev_perf_level_t. This value is then
+ *  passed as a uint32_t val to the Go routine that
+ *  called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint32_t performance level (rsmi_dev_perf_level_t)
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint32_t go_shim_rsmi_dev_perf_level_get(uint32_t dv_ind);
+
+/**
  *  @brief Go language stub to get the GPU SCLK limit
  *
  *  @details This function will call the rsmi_dev_gpu_clk_freq_get()
@@ -156,6 +284,70 @@ uint64_t go_shim_rsmi_dev_gpu_clk_freq_get_sclk(uint32_t dv_ind);
  *
  */
 uint64_t go_shim_rsmi_dev_gpu_clk_freq_get_mclk(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the minimum supported SCLK frequency
+ *
+ *  @details This function will call the rsmi_od_volt_freq_data_get()
+ *  function to return the minium supported SCLK frequency.
+ *  This value is then passed as a uint64_t val to the Go routine that
+ *  called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint64_t mimimum supported sclk frequency
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint64_t go_shim_rsmi_od_volt_freq_range_min_get_sclk(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the minimum supported MCLK frequency
+ *
+ *  @details This function will call the rsmi_od_volt_freq_data_get()
+ *  function to return the minium supported MCLK frequency.
+ *  This value is then passed as a uint64_t val to the Go routine that
+ *  called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint64_t mimimum supported mclk sfrequency
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint64_t go_shim_rsmi_od_volt_freq_range_min_get_mclk(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the maximum supported SCLK frequency
+ *
+ *  @details This function will call the rsmi_od_volt_freq_data_get()
+ *  function to return the maxium supported SCLK frequency.
+ *  This value is then passed as a uint64_t val to the Go routine that
+ *  called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint64_t maximum supported sclk frequency
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint64_t go_shim_rsmi_od_volt_freq_range_max_get_sclk(uint32_t dv_ind);
+
+/**
+ *  @brief Go language stub to get the maximum supported MCLK frequency
+ *
+ *  @details This function will call the rsmi_od_volt_freq_data_get()
+ *  function to return the maxium supported MCLK frequency.
+ *  This value is then passed as a uint64_t val to the Go routine that
+ *  called it.
+ *
+ *  @param[in] ::uint32_t device index
+ *
+ *  @retval ::uint64_t maximum supported mclk sfrequency
+ *  @retval zero is returned upon failure.
+ *
+ */
+uint64_t go_shim_rsmi_od_volt_freq_range_max_get_mclk(uint32_t dv_ind);
 
 /**
  *  @brief Go language stub to get the GPU Activity


### PR DESCRIPTION
New rsmi calls added
rsmi_shut_down
rsmi_dev_name_get
rsmi_dev_pci_id_get
rsmi_dev_vendor_name_get
rsmi_dev_vbios_version_get
rsmi_dev_power_cap_get
rsmi_dev_perf_level_get
rsmi_dev_overdrive_level_get (sclk and mclk)
rsmi_dev_od_volt_info_get (sclk and mclk, min and max)